### PR TITLE
Update ZUOYA GMK26 configuration with new firmware json

### DIFF
--- a/premade/Zuoya_GMK26/README.md
+++ b/premade/Zuoya_GMK26/README.md
@@ -25,8 +25,12 @@ Personally, I think the default sound profile is nice. Not the deepest, but not 
 ## VIA
 The macropad works with VIA, and that's nice.
 
-1. Download the JSON file [ZUOYA_GMK26_20240517.json](ZUOYA_GMK26_20240517.json) from this repo. It took over a month, but ZUOYA finally send it to me. 
-    - 🟠 TODO: fix [ZUOYA_GMK26.json](ZUOYA_GMK26.json), my simplified, English-only version of the json from [the Korean NAVER blog](https://blog.naver.com/PostView.naver?blogId=thrufunlife&logNo=223557922108&noTrackingCode=true). I removed the encoder toggle as you can't physically remove the encoder, but remove the wrong option -- facepalm.
+1. Download the latest version of the JSON file: [**ZUOYA_GMK26.json**](ZUOYA_GMK26.json) from this repository.  
+   This file is sourced from the official [ZUOYA firmware downloads page](http://zuoya.top/qdxz_04161229_941).
+
+   > ⚠️ If this JSON file doesn't work with your keyboard, you might have an older version of the hardware.  
+   > In that case, try using one of the older JSON files available in the current folder
+
 2. Open [usevia.app](http://usevia.app) in a Chromium-based browser.
 3. Under`Settings`, activate `Show Design tab`.
 4. Load the JSON file:

--- a/premade/Zuoya_GMK26/ZUOYA_GMK26.json
+++ b/premade/Zuoya_GMK26/ZUOYA_GMK26.json
@@ -1,35 +1,11 @@
 {
-    "name": "ZUOYA GMK26",
-    "vendorId": "0x28E9",
-    "productId": "0x3014",
-    "matrix": {"rows": 6, "cols": 6},
-
-    "layouts":{
-
-      "keymap":[
-        ["0,0\n\n\n\n\n\ne0",{"x":0.5},"0,2","0,3","0,4\n\n\n0,0","1,5\n\n\n0,0",
-          {"w":2},"0,5\n\n\n0,1"],
-        ["1,0",{"x":0.5},"1,1","1,2","1,3","1,4"],
-        ["2,0",{"x":0.5},"2,1","2,2","2,3",{"h":2},"2,4"],
-        ["3,0",{"x":0.5},"3,1","3,2","3,3"],
-        ["4,0",{"x":0.5},"4,1","4,2","4,3",{"h":2},"5,3"],
-        ["5,0",{"x":0.5},{"w":2},"5,1","5,2"]
-        ],
-        "labels": [
-        "Split Backspace or Big Backspace"
-      ]
-    },
-
-    "keycodes": ["qmk_lighting"],
-    "customKeycodes": [
-      {"name": "2.4G", "title": "2.4G Host", "shortName": "2.4G"},
-      {"name": "Bluetooth Host 1","title": "Bluetooth Host 1", "shortName": "BLE1"},
-      {"name": "Bluetooth Host 2","title": "Bluetooth Host 2", "shortName": "BLE2"},
-      {"name": "Bluetooth Host 3","title": "Bluetooth Host 3", "shortName": "BLE3"},
-      {"name": "Reset","title": "MCU Reset", "shortName": "Reset"},
-      {"name": "Battery Level", "title": "Battery Level", "shortName": "Batt"}
-      ],
-    "menus": [
+  "name": "ZUOYA GMK26",
+  "vendorId": "0x36B0",
+  "productId": "0x3083",
+  "keycodes": [
+    "qmk_lighting"
+  ],
+  "menus": [
     {
       "label": "Lighting",
       "content": [
@@ -39,72 +15,551 @@
             {
               "label": "Brightness",
               "type": "range",
-              "options": [0, 255],
-              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+              "options": [
+                0,
+                200
+              ],
+              "content": [
+                "id_qmk_rgb_matrix_brightness",
+                3,
+                1
+              ]
             },
             {
               "label": "Effect",
               "type": "dropdown",
-              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "content": [
+                "id_qmk_rgb_matrix_effect",
+                3,
+                2
+              ],
               "options": [
-                "All Off",
-                "Solid Color",
-                "Gradient Up/Down",
-                "Gradient Left/Right",
-                "Breathing",
-                "Band Sat.",
-                "Band Val.",
-                "Pinwheel Sat.",
-                "Pinwheel Val.",
-                "Spiral Sat.",
-                "Spiral Val.",
-                "Cycle All",
-                "Cycle Left/Right",
-                "Cycle Up/Down",
-                "Cycle Out/In",
-                "Cycle Out/In Dual",
-                "Rainbow Moving Chevron",
-                "Cycle Pinwheel",
-                "Cycle Spiral",
-                "Dual Beacon",
-                "Rainbow Beacon",
-                "Rainbow Pinwheels",
-                "Hue Breathing",
-                "Hue Pendulum",
-                "Hue Wave",
-                "Typing Heatmap",
-                "Digital Rain",
-                "Solid Reactive Simple",
-                "Solid Reactive",
-                "- Solid Reactive Wide",
-                "- Solid Reactive Multi Wide",
-                "- Solid Reactive Cross",
-                "- Solid Reactive Multi Cross",
-                "- Solid Reactive Nexus",
-                "- Solid Reactive Multi Nexus",
-                "Spash",
-                "Multi Splash",
-                "Solid Splash",
-                "Solid Multi Splash"
+                [
+                  "none",
+                  0
+                ],
+                [
+                  "solid_color",
+                  1
+                ],
+                [
+                  "alphas_mods",
+                  2
+                ],
+                [
+                  "gradient_up_down",
+                  3
+                ],
+                [
+                  "gradient_left_right",
+                  4
+                ],
+                [
+                  "breathing",
+                  5
+                ],
+                [
+                  "band_sat",
+                  6
+                ],
+                [
+                  "band_val",
+                  7
+                ],
+                [
+                  "band_pinwheel_sat",
+                  8
+                ],
+                [
+                  "band_pinwheel_val",
+                  9
+                ],
+                [
+                  "band_spiral_sat",
+                  10
+                ],
+                [
+                  "band_spiral_val",
+                  11
+                ],
+                [
+                  "cycle_all",
+                  12
+                ],
+                [
+                  "cycle_left_right",
+                  13
+                ],
+                [
+                  "cycle_up_down",
+                  14
+                ],
+                [
+                  "cycle_out_in",
+                  15
+                ],
+                [
+                  "cycle_out_in_dual",
+                  16
+                ],
+                [
+                  "rainbow_moving_chevron",
+                  17
+                ],
+                [
+                  "cycle_pinwheel",
+                  18
+                ],
+                [
+                  "cycle_spiral",
+                  19
+                ],
+                [
+                  "dual_beacon",
+                  20
+                ],
+                [
+                  "rainbow_beacon",
+                  21
+                ],
+                [
+                  "rainbow_pinwheels",
+                  22
+                ],
+                [
+                  "flower_blooming",
+                  23
+                ],
+                [
+                  "raindrops",
+                  24
+                ],
+                [
+                  "jellybean_raindrops",
+                  25
+                ],
+                [
+                  "hue_breathing",
+                  26
+                ],
+                [
+                  "hue_pendulum",
+                  27
+                ],
+                [
+                  "hue_wave",
+                  28
+                ],
+                [
+                  "pixel_flow",
+                  29
+                ],
+                [
+                  "digital_rain",
+                  30
+                ],
+                [
+                  "solid_reactive",
+                  31
+                ],
+                [
+                  "solid_reactive_wide",
+                  32
+                ],
+                [
+                  "solid_reactive_multiwide",
+                  33
+                ],
+                [
+                  "solid_reactive_cross",
+                  34
+                ],
+                [
+                  "solid_reactive_multicross",
+                  35
+                ],
+                [
+                  "solid_reactive_nexus",
+                  36
+                ],
+                [
+                  "solid_reactive_multinexus",
+                  37
+                ],
+                [
+                  "splash",
+                  38
+                ],
+                [
+                  "multisplash",
+                  39
+                ],
+                [
+                  "solid_splash",
+                  40
+                ],
+                [
+                  "solid_multisplash",
+                  41
+                ],
+                [
+                  "starlight",
+                  42
+                ],
+                [
+                  "starlight_dual_hue",
+                  43
+                ],
+                [
+                  "starlight_dual_sat",
+                  44
+                ],
+                [
+                  "riverflow",
+                  45
+                ]
               ]
             },
             {
               "showIf": "{id_qmk_rgb_matrix_effect} != 0",
               "label": "Effect Speed",
               "type": "range",
-              "options": [0, 255],
-              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+              "options": [
+                0,
+                255
+              ],
+              "content": [
+                "id_qmk_rgb_matrix_effect_speed",
+                3,
+                3
+              ]
             },
             {
               "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 24 && {id_qmk_rgb_matrix_effect} != 28 && {id_qmk_rgb_matrix_effect} != 29 && {id_qmk_rgb_matrix_effect} != 32",
               "label": "Color",
               "type": "color",
-              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+              "content": [
+                "id_qmk_rgb_matrix_color",
+                3,
+                4
+              ]
             }
           ]
         }
       ]
     }
-  ]
+  ],
+  "customKeycodes": [
+    {
+      "name": "2.4G",
+      "title": "Set to 2.4G working mode",
+      "shortName": "MD_24G"
+    },
+    {
+      "name": "BLE1",
+      "title": "Set to Bluetooth Channel 1 working mode",
+      "shortName": "MD_BLE1"
+    },
+    {
+      "name": "BLE2",
+      "title": "Set to Bluetooth Channel 2 working mode",
+      "shortName": "MD_BLE2"
+    },
+    {
+      "name": "BLE3",
+      "title": "Set to Bluetooth Channel 3 working mode",
+      "shortName": "MD_BLE3"
+    },
+    {
+      "name": "USB",
+      "title": "Set to USB working mode",
+      "shortName": "MD_USB"
+    },
+    {
+      "name": "BAT",
+      "title": "Querying Battery Status",
+      "shortName": "QK_BAT"
+    },
+    {
+      "name": "WLO",
+      "title": "Lock WIN",
+      "shortName": "QK_WLO"
+    },
+    {
+      "name": "SIX_N",
+      "title": "Full-key six-key switch",
+      "shortName": "SIX_N"
+    },
+    {
+      "name": "RTOG",
+      "title": "Toggle led lighting on or off",
+      "shortName": "RGB_RTOG"
+    },
+    {
+      "name": "U_EE_CLR",
+      "title": "Customize the reset button",
+      "shortName": "U_EE_CLR"
+    },
+    {
+      "name": "QK_DEB",
+      "title": "Number of times that the key shakes off",
+      "shortName": "QK_DEB"
+    }
+  ],
+  "matrix": {
+    "rows": 6,
+    "cols": 7
+  },
+  "layouts": {
+    "labels": [
+      "Split Encoder",
+      "ISO Enter"
+    ],
+    "keymap": [
+      [
+        {
+          "c": "#777777"
+        },
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "0,0\n\n\n0,1",
+        {
+          "c": "#777777",
+          "w": 1.0,
+          "h": 1.0,
+          "x": -1.0,
+          "fa": [
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+          ]
+        },
+        "0,6\n\n\n0,0\n\n\n\n\n\n e0 ",
+        {
+          "c": "#aaaaaa"
+        },
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.25
+        },
+        "0,1",
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "0,2",
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "0,3\n\n\n1,0",
+        {
+          "w": 2.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "0,4\n\n\n1,1",
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": -2.0
+        },
+        "0,5\n\n\n1,0"
+      ],
+      [
+        {
+          "y": 0.25
+        },
+        {
+          "c": "#777777"
+        },
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "1,0",
+        {
+          "c": "#aaaaaa"
+        },
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.25
+        },
+        "1,1",
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "1,2",
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "1,3",
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "1,4"
+      ],
+      [
+        {
+          "c": "#777777"
+        },
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "2,0",
+        {
+          "c": "#cccccc"
+        },
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.25
+        },
+        "2,1",
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "2,2",
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "2,3",
+        {
+          "c": "#aaaaaa"
+        },
+        {
+          "w": 1.0,
+          "h": 2.0,
+          "x": 0.0
+        },
+        "2,4"
+      ],
+      [
+        {
+          "c": "#777777"
+        },
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "3,0",
+        {
+          "c": "#cccccc"
+        },
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.25
+        },
+        "3,1",
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "3,2",
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "3,3"
+      ],
+      [
+        {
+          "c": "#777777"
+        },
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "4,0",
+        {
+          "c": "#cccccc"
+        },
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.25
+        },
+        "4,1",
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "4,2",
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "4,3",
+        {
+          "c": "#aaaaaa"
+        },
+        {
+          "w": 1.0,
+          "h": 2.0,
+          "x": 0.0
+        },
+        "5,3"
+      ],
+      [
+        {
+          "c": "#777777"
+        },
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "5,0",
+        {
+          "c": "#cccccc"
+        },
+        {
+          "w": 2.0,
+          "h": 1.0,
+          "x": 0.25
+        },
+        "5,1",
+        {
+          "w": 1.0,
+          "h": 1.0,
+          "x": 0.0
+        },
+        "5,2"
+      ]
+    ]
+  }
 }
-

--- a/premade/Zuoya_GMK26/ZUOYA_GMK26_V1.json
+++ b/premade/Zuoya_GMK26/ZUOYA_GMK26_V1.json
@@ -1,0 +1,110 @@
+{
+    "name": "ZUOYA GMK26",
+    "vendorId": "0x28E9",
+    "productId": "0x3014",
+    "matrix": {"rows": 6, "cols": 6},
+
+    "layouts":{
+
+      "keymap":[
+        ["0,0\n\n\n\n\n\ne0",{"x":0.5},"0,2","0,3","0,4\n\n\n0,0","1,5\n\n\n0,0",
+          {"w":2},"0,5\n\n\n0,1"],
+        ["1,0",{"x":0.5},"1,1","1,2","1,3","1,4"],
+        ["2,0",{"x":0.5},"2,1","2,2","2,3",{"h":2},"2,4"],
+        ["3,0",{"x":0.5},"3,1","3,2","3,3"],
+        ["4,0",{"x":0.5},"4,1","4,2","4,3",{"h":2},"5,3"],
+        ["5,0",{"x":0.5},{"w":2},"5,1","5,2"]
+        ],
+        "labels": [
+        "Split Backspace or Big Backspace"
+      ]
+    },
+
+    "keycodes": ["qmk_lighting"],
+    "customKeycodes": [
+      {"name": "2.4G", "title": "2.4G Host", "shortName": "2.4G"},
+      {"name": "Bluetooth Host 1","title": "Bluetooth Host 1", "shortName": "BLE1"},
+      {"name": "Bluetooth Host 2","title": "Bluetooth Host 2", "shortName": "BLE2"},
+      {"name": "Bluetooth Host 3","title": "Bluetooth Host 3", "shortName": "BLE3"},
+      {"name": "Reset","title": "MCU Reset", "shortName": "Reset"},
+      {"name": "Battery Level", "title": "Battery Level", "shortName": "Batt"}
+      ],
+    "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+              "label": "Effect",
+              "type": "dropdown",
+              "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+              "options": [
+                "All Off",
+                "Solid Color",
+                "Gradient Up/Down",
+                "Gradient Left/Right",
+                "Breathing",
+                "Band Sat.",
+                "Band Val.",
+                "Pinwheel Sat.",
+                "Pinwheel Val.",
+                "Spiral Sat.",
+                "Spiral Val.",
+                "Cycle All",
+                "Cycle Left/Right",
+                "Cycle Up/Down",
+                "Cycle Out/In",
+                "Cycle Out/In Dual",
+                "Rainbow Moving Chevron",
+                "Cycle Pinwheel",
+                "Cycle Spiral",
+                "Dual Beacon",
+                "Rainbow Beacon",
+                "Rainbow Pinwheels",
+                "Hue Breathing",
+                "Hue Pendulum",
+                "Hue Wave",
+                "Typing Heatmap",
+                "Digital Rain",
+                "Solid Reactive Simple",
+                "Solid Reactive",
+                "- Solid Reactive Wide",
+                "- Solid Reactive Multi Wide",
+                "- Solid Reactive Cross",
+                "- Solid Reactive Multi Cross",
+                "- Solid Reactive Nexus",
+                "- Solid Reactive Multi Nexus",
+                "Spash",
+                "Multi Splash",
+                "Solid Splash",
+                "Solid Multi Splash"
+              ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 24 && {id_qmk_rgb_matrix_effect} != 28 && {id_qmk_rgb_matrix_effect} != 29 && {id_qmk_rgb_matrix_effect} != 32",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
# Update ZUOYA GMK26 configuration with new firmware JSON

## Summary
This PR addresses issue #6 by updating the ZUOYA GMK26 configuration with the latest official firmware JSON file from ZUOYA. The new JSON file resolves VIA device detection issues that users have been experiencing.

## Problem Solved
Multiple users reported VIA device detection issues with the GMK26 macropad. I recently bought a GMK26 and ran into the same problem - the older JSON file (`ZUOYA_GMK26_20240517.json`) wasn't working at all. I spent ages trying to debug the issue, testing different configurations and troubleshooting VIA settings, until I finally discovered ZUOYA's really obscure official website that had the v2 firmware with the updated JSON file. This update uses that official JSON file from ZUOYA's firmware downloads page (v2 firmware archive dated 20250329), which has been confirmed to fix these detection issues.

## Changes Made
- **Updated JSON file**: Replaced the old configuration with the official `ZUOYA_GMK26.json` from ZUOYA's firmware downloads page
- **Updated README**: Modified documentation to reflect the new JSON file source and provide clearer instructions
- **Added compatibility note**: Included warning about potential hardware version compatibility issues




Closes #6